### PR TITLE
php-posix now required for composer

### DIFF
--- a/community/installation-guides/panel/centos8.md
+++ b/community/installation-guides/panel/centos8.md
@@ -46,7 +46,7 @@ dnf install -y php php-{common,fpm,cli,json,mysqlnd,gd,mbstring,pdo,zip,bcmath,d
 
 ### Composer
 ```bash
-dnf install -y zip unzip tar # Required for Composer
+dnf install -y zip unzip tar php-posix # Required for Composer
 curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ```
 


### PR DESCRIPTION
Kindof dumb, but I guess its something that composer requires on new installs.